### PR TITLE
Add option for a preview line to textDocument/references

### DIFF
--- a/protocol.md
+++ b/protocol.md
@@ -229,6 +229,15 @@ interface Location {
 }
 ```
 
+#### Preview Location
+
+Represents a location inside a resource, such as a line inside a text file.
+```typescript
+interface LocationPreview extends Location {
+	contents: string;
+}
+```
+
 #### Diagnostic
 
 Represents a diagnostic, such as a compiler error or warning. Diagnostic objects are only valid in the scope of a resource.
@@ -1231,10 +1240,14 @@ interface ReferenceContext {
 	 * Include the declaration of the current symbol.
 	 */
 	includeDeclaration: boolean;
+	/**
+	 * Include preview of line where reference occurs.
+	 */
+	includePreview: boolean;
 }
 ```
 _Response_:
-* result: [`Location`](#location)[]
+* result: [`Location`](#location)[] | [`LocationPreview`](#location-preview)[]
 * error: code and message set in case an exception happens during the reference request.
 
 #### Document Highlights Request


### PR DESCRIPTION
I'm implementing an editor extension that will connect to a language server to display references to a symbol in Sublime.

As specified, the LSP textDocument/references call returns `Location[]`, which _just_ have uri and range information for the symbol references.

There are many situations where the user of a language server would want a preview of the reference. I think this use case might be common enough to warrant modifying LSP to allow for that.

Reasons to include preview with references:
- Efficiently accessing many files and extracting lines is harder from editor plugin environments than in a language server process.
- Many editors would need a preview for references - Sublime, VSCode, and many others already have this requirement. It seems common enough to warrant an API call.
- The [Microsoft TypeScript Sublime](https://github.com/Microsoft/TypeScript-Sublime-Plugin) plugin's bundled TypeScript language server [does this](https://github.com/Microsoft/TypeScript-Sublime-Plugin/blob/master/typescript/commands/references.py#L128).
- Servers implementing `textDocument/refences` need to open the file where the reference occurs already, so would they likely get this for free.

Reasons not to include preview:
- For editors like VSCode that support previews via the peek pane, the code and logic for acquiring chunks from different files already exists, so why duplicate code paths.

Open to suggestions, thanks!