### PR TITLE
workspace/xreferences: change WorkspaceReferencesParams.files to .hints

### DIFF
--- a/extension-workspace-references.md
+++ b/extension-workspace-references.md
@@ -46,7 +46,9 @@ interface WorkspaceReferencesParams {
      * look in order to find the symbol (this is an optimization). It is up to
      * the language server to define the schema of this object.
      */
-    [hints: string]: any;
+    hints: {
+        [hint: string]: any;
+    }
 }
 ```
 

--- a/extension-workspace-references.md
+++ b/extension-workspace-references.md
@@ -42,9 +42,11 @@ interface WorkspaceReferencesParams {
     query: Partial<SymbolDescriptor>;
 
     /**
-     * An optional list of files to restrict the search to.
+     * Hints provides optional hints about where the language server should
+     * look in order to find the symbol (this is an optimization). It is up to
+     * the language server to define the schema of this object.
      */
-    files?: string[];
+    [hints: string]: any;
 }
 ```
 


### PR DESCRIPTION
This more appropriately represents the data at hand. A language server
may choose any hints -- not just files. These are primarily derived from
a build server's workspace/xdependencies method results.