### PR TITLE
Add spec for workspace/xdependencies

### DIFF
--- a/extension-workspace-references.md
+++ b/extension-workspace-references.md
@@ -21,6 +21,11 @@ interface ServerCapabilities {
    * The server provides extended text document definition support.
    */
   xdefinitionProvider?: boolean;
+
+  /**
+   * The server provides support for retrieving the workspace's dependencies
+   */
+  xdependenciesProvider?: boolean;
 }
 ```
 

--- a/extension-workspace-references.md
+++ b/extension-workspace-references.md
@@ -117,3 +117,31 @@ interface SymbolLocationInformation {
 }
 ```
 * error: code and message set in case an exception happens during the definition request.
+
+### Dependencies Request
+
+This method returns the dependencies of this workspace.
+
+_Request_
+* method: 'workspace/xdependencies'
+* params: none
+
+_Response_:
+* result: `DependencyReference[]` where `DependencyReference` is defined as follows:
+```typescript
+/**
+ * Contains information about a package the workspace depends on
+ */
+interface DependencyReference {
+    /**
+     * ?
+     */
+    hints?: { [hint: string]: any };
+
+    /**
+     * Language-specific attributes about the package
+     */
+    attributes: { [attribute: string]: any };
+}
+```
+* error: code and message set in case an exception happens during the definition request.


### PR DESCRIPTION
This adds the missing spec for `workspace/xdependencies`, closes https://github.com/sourcegraph/sourcegraph/issues/3035.

@stephen or @beyang could you please confirm this is correct and fill out the missing documentation for `hints` (I don't understand the its purpose, seems like it is not needed in PHP)