### PR TITLE
Allow to query workspace/symbols by a SymbolDescriptor

### DIFF
--- a/extension-workspace-references.md
+++ b/extension-workspace-references.md
@@ -21,6 +21,12 @@ interface ServerCapabilities {
    * The server provides extended text document definition support.
    */
   xdefinitionProvider?: boolean;
+
+  /**
+   * The server provides support for querying symbols by properties
+   * with WorkspaceSymbolParams.symbol
+   */
+  xworkspaceSymbolByProperties?: boolean;
 }
 ```
 

--- a/extension-workspace-references.md
+++ b/extension-workspace-references.md
@@ -117,3 +117,26 @@ interface SymbolLocationInformation {
 }
 ```
 * error: code and message set in case an exception happens during the definition request.
+
+
+### Extended Workspace Symbol Request
+
+The `workspace/symbol` request takes an optional parameter `symbol` that allows you to query by known properties about the symbol.
+The string `query` parameter becomes optional.
+
+```typescript
+/**
+ * The parameters of a Workspace Symbol Request.
+ */
+interface WorkspaceSymbolParams {
+    /**
+     * A query string
+     */
+    query?: string;
+
+    /**
+     * Known properties about the symbol.
+     */
+    symbol?: Partial<SymbolDescriptor>;
+}
+```

--- a/extension-workspace-references.md
+++ b/extension-workspace-references.md
@@ -123,6 +123,16 @@ interface SymbolLocationInformation {
 
 The `workspace/symbol` request takes an optional parameter `symbol` that allows you to query by known properties about the symbol.
 The string `query` parameter becomes optional.
+If both `query` and `symbol` are provided, both should both be matched with AND semantics.
+
+#### Differences between `symbol` and `query`
+
+ `query`                             | `symbol`
+-------------------------------------|------------------------------------
+ comes from user input in UI         | used programmatically
+ matches as fuzzily as possible      | matches as exact as possible
+ returns as many results as possible | returns as few results as possible
+
 
 ```typescript
 /**


### PR DESCRIPTION
Use cases are constructing symbol URLs and global j2d.

Discussed with @rothfels and @beyang 