### PR TITLE
Remove SymbolDescriptor, extend SymbolInformation

### DIFF
--- a/extension-workspace-references.md
+++ b/extension-workspace-references.md
@@ -24,7 +24,29 @@ interface ServerCapabilities {
 }
 ```
 
-#### Workspace References Request
+### Extended `SymbolInformation`
+
+This extension defines a few more properties on `SymbolInformation`.
+
+```ts
+interface SymbolInformation {
+
+    // ... all properties from the base SymbolInformation
+
+    /**
+     * A globally unique identifier for the the symbol, if the language server is able to construct one.
+     */
+    id?: string;
+
+    /**
+     * Contains information about the package this symbol is contained in.
+     * The properties that describe the package are language-dependent.
+     */
+    package?: { [key: string]: any; };
+}
+```
+
+### Workspace References Request
 
 The workspace references request is sent from the client to the server to locate project-wide references to a symbol given its description / metadata.
 
@@ -39,7 +61,7 @@ interface WorkspaceReferencesParams {
     /**
      * Metadata about the symbol that is being searched for.
      */
-    query: Partial<SymbolDescriptor>;
+    query: Partial<SymbolInformation>;
 
     /**
      * An optional list of files to restrict the search to.
@@ -65,55 +87,21 @@ interface ReferenceInformation {
      * Metadata about the symbol that can be used to identify or locate its
      * definition.
      */
-    symbol: SymbolDescriptor;
+    symbol: Partial<SymbolInformation>;
 }
 ```
 * error: code and message set in case an exception happens during the workspace references request.
 
-Where `SymbolDescriptor` is defined as follows:
-
-```typescript
-/**
- * Represents information about a programming construct that can be used to
- * identify and locate the construct's symbol. The identification does not have
- * to be unique, but it should be as unique as possible. It is up to the
- * language server to define the schema of this object.
- *
- * In contrast to `SymbolInformation`, `SymbolDescriptor` includes more concrete,
- * language-specific, metadata about the symbol.
- */
-interface SymbolDescriptor {
-    /**
-     * A list of properties of a symbol that can be used to identify or locate
-     * it.
-     */
-    [attr: string]: any
-}
-```
-
 ### Goto Definition Extension Request
 
-This method is the same as `textDocument/definition`, except that:
+This method is the same as `textDocument/definition`, except that instead of returning only the location, it returns a partial `SymbolInformation` with as many information about the symbol as possible.
 
-1. The method returns metadata about the definition (the same metadata that `workspace/xreferences` searches for).
-2. The concrete location to the definition (`location` field) is optional. This is useful because the language server might not be able to resolve a goto definition request to a concrete location (e.g. due to lack of dependencies) but still may know _some_ information about it.
+The result can be passed into `workspace/xreferences` to search for.
 
 _Request_
 * method: 'textDocument/xdefinition'
 * params: [`TextDocumentPositionParams`](#textdocumentpositionparams)
 
 _Response_:
-* result: `SymbolLocationInformation[]` defined as follows:
-```typescript
-interface SymbolLocationInformation {
-    /* The location where the symbol is defined, if any. */
-    location?: Location;
-
-    /**
-     * Metadata about the symbol that can be used to identify or locate its
-     * definition.
-     */
-    symbol: SymbolDescriptor;
-}
-```
+* result: `Partial<SymbolInformation>[]`
 * error: code and message set in case an exception happens during the definition request.


### PR DESCRIPTION
After the workspace/references extension has been implemented and used in some languages I wanted to take a step back and reflect on the usage and how we could improve the spec by that.

It is a fact that `SymbolDescriptor` and `SymbolInformation` have pretty much the same semantics, they describe a symbol (and that fact will make it hard to ever propose this upstream). The initial reason for defining two interfaces back then was that we didn't want to force a language server to have to return _all_ properties of `SymbolInformation`, because properties like `location` could be expensive to resolve (personally, since my LS keeps `SymbolInformation`s in memory, that has not been a problem). TypeScript now has a new syntax though to express this elegantly (`Partial`), so we can use `SymbolInformation` without requiring the language server to return all properties.

The difference in the specification between `SymbolDescriptor` and `SymbolInformation` is that `SymbolDescriptor` is entirely language-server-defined. This made it easy to get a quick spec out and was fine as long as the only real use for the result was passing it back in as a parameter to `workspace/references`. Now that we may want to use `SymbolDescriptor` in more places (for example for `workspace/symbols`, #12) there is benefit in having a more well-defined interface for describing symbols. Especially `SymbolLocationInformation` ended up being weird, because `SymbolDescriptor` was supposed to contain as many information about the symbol as possible (which may already include the location), but then the `SymbolLocationInformation` included the location again. Moving the additional information of `SymbolDescriptor` (like package information) over to `SymbolInformation` has the additional advantage of allowing the language server to return this information in more places. For example `workspace/symbol` could then also return package information and a symbol ID in the results, if known.

From what I got from the implementations and uses was that the only important addition to `SymbolDescriptor` compared to `SymbolInformation` was package information, so this spec adds a `package` field to `SymbolInformation`, which is still language-defined. It may be beneficial to define a property that should contain a unique identifier for the package, which would save us from language-specific code in the client (for example `package.id`, which would be the value of `name` for JS/TS and PHP).
For the purposes of #12, this spec adds an `id` field to `SymbolInformation`, which may contain a globally unique identifier for the symbol.
Are there any other fields that we need to know about regarding symbols? Will this cover all use cases?

@slimsag @beyang WDYT?