### PR TITLE
workspace/symbol textDocument parameter

### DIFF
--- a/protocol.md
+++ b/protocol.md
@@ -2208,7 +2208,7 @@ interface WorkspaceSymbolParams {
 	/**
 	 * Identifies the textDocument that is currently active.
 	 */
-	textDocument?: TextDocumentIdentifier;
+	xtextDocument?: TextDocumentIdentifier;
 }
 ```
 

--- a/protocol.md
+++ b/protocol.md
@@ -2208,7 +2208,7 @@ interface WorkspaceSymbolParams {
 	/**
 	 * Identifies the textDocument that is currently active.
 	 */
-	xtextDocument?: TextDocumentIdentifier;
+	xactiveTextDocument?: TextDocumentIdentifier;
 }
 ```
 

--- a/protocol.md
+++ b/protocol.md
@@ -2190,7 +2190,7 @@ _Registration Options_: `TextDocumentRegistrationOptions`
 
 #### <a name="workspace_symbol"></a>Workspace Symbols Request
 
-The workspace symbol request is sent from the client to the server to list project-wide symbols matching the query string. The text document parameter specifies the active document at time of the query. This can be used to scope the search to a specific workspace if the document tree contains multiple workspaces. If textDocument is undefined and there is only one workspace in the document tree, then `workspace/symbol` should return results from that workspace. If there are multiple workspaces, the behavior is undefined.
+The workspace symbol request is sent from the client to the server to list project-wide symbols matching the query string. The text document parameter specifies the active document at time of the query. This can be used to rank or limit results.
 
 _Request_:
 * method: 'workspace/symbol'
@@ -2207,8 +2207,8 @@ interface WorkspaceSymbolParams {
 
 	/**
 	 * Identifies the textDocument that is currently active.
-         */
-        textDocument?: TextDocumentIdentifier;
+	 */
+	textDocument?: TextDocumentIdentifier;
 }
 ```
 

--- a/protocol.md
+++ b/protocol.md
@@ -2190,7 +2190,7 @@ _Registration Options_: `TextDocumentRegistrationOptions`
 
 #### <a name="workspace_symbol"></a>Workspace Symbols Request
 
-The workspace symbol request is sent from the client to the server to list project-wide symbols matching the query string.
+The workspace symbol request is sent from the client to the server to list project-wide symbols matching the query string. The text document parameter specifies the active document at time of the query. This can be used to scope the search to a specific workspace if the file tree contains multiple workspaces.
 
 _Request_:
 * method: 'workspace/symbol'
@@ -2204,6 +2204,11 @@ interface WorkspaceSymbolParams {
 	 * A non-empty query string
 	 */
 	query: string;
+
+	/**
+	 * Identifies the textDocument that is currently active.
+         */
+        textDocument?: TextDocumentIdentifier;
 }
 ```
 

--- a/protocol.md
+++ b/protocol.md
@@ -2190,7 +2190,7 @@ _Registration Options_: `TextDocumentRegistrationOptions`
 
 #### <a name="workspace_symbol"></a>Workspace Symbols Request
 
-The workspace symbol request is sent from the client to the server to list project-wide symbols matching the query string. The text document parameter specifies the active document at time of the query. This can be used to scope the search to a specific workspace if the file tree contains multiple workspaces.
+The workspace symbol request is sent from the client to the server to list project-wide symbols matching the query string. The text document parameter specifies the active document at time of the query. This can be used to scope the search to a specific workspace if the document tree contains multiple workspaces. If textDocument is undefined and there is only one workspace in the document tree, then `workspace/symbol` should return results from that workspace. If there are multiple workspaces, the behavior is undefined.
 
 _Request_:
 * method: 'workspace/symbol'


### PR DESCRIPTION
Currently, we interpret `workspace/symbol` to mean "repository-wide symbol search". Oftentimes, a single repository will contain multiple workspaces, potentially written in different languages. This is the case for both large open-source repositories (especially in languages like Java) and private repositories (consider our own Sourcegraph repo, which has both frontend and backend code across different languages). Doing repo-wide search is bad for UX in a couple of ways:

- It crowds the results with potentially irrelevant results. Typically people explore code on a project-by-project basis (many IDEs don't even gracefully support having multiple projects open at the same time). If I'm looking at front-end TypeScript code and I search for a symbol, I probably don't want to see symbols from Go.
- It makes results slower. When invoked on large repositories with multiple workspaces, `workspace/symbol` must wait for results to be collected from each workspace. If I'm exploring a relatively small subproject workspace, I don't want to wait for results to be collected from a much larger project in the same repo.

A counterargument to this proposal is that sometimes it's convenient to jump across workspaces in the same repository. For instance, if I'm considering front-end code that hits an API, I might want to jump to the backend code that responds to the client. I argue that it's okay to make this a two-step operation for the sake of addressing the two issues above. Moreover, in the case of multiple workspaces, results from other workspaces might crowd out results from the workspace I intend to jump to.

The current behavior is also not really spec-compliant, as the spec specifies `workspace/symbol` to search across a workspace (the spec also implies there is only one workspace active at a time, but this is clearly not the case, both for Sourcegraph and for people editing code who need to work on multiple projects simultaneously).

Note that the behavior hear is more clear-cut in some languages than others. For instance, in Java, JavaScript, TypeScript, and PHP, a workspace is probably defined by the existence of a `pom.xml`, `package.json`/`tsconfig.json`, `composer.json`, but in Go, it might make sense to define a workspace as "the highest-level directory that contains Go files at every level of the source tree (i.e., no subdirectories with no go files)."