### PR TITLE
Workspace references cleanup

### DIFF
--- a/extension-workspace-references.md
+++ b/extension-workspace-references.md
@@ -156,3 +156,40 @@ interface WorkspaceSymbolParams {
     symbol?: Partial<SymbolDescriptor>;
 }
 ```
+
+### Workspace Packages Request
+
+This method returns metadata about the package(s) defined in a
+workspace and a list of dependencies for each package.
+
+This method is necessary to implement cross-repository jump-to-def
+when it is not possible to resolve the global location of the
+definition from data present or derived from the local workspace. For
+example, a package manager might not include information about the
+source repository of each dependency. In this case, definition
+resolution requires mapping from package descriptor to repository
+revision URL. A reverse index can be constructed from calls to
+`workspace/xpackages` to provide an efficient mapping.
+
+_Request_
+* method: 'workspace/xpackages'
+* params: `void`
+
+_Response_:
+* result: `PackageInformation[]`
+```typescript
+interface PackageInformation {
+	/* The package identifier, e.g., name and version. */
+	package: PackageDescriptor;
+
+	/* The list of package dependencies */
+	dependencies: DependencyReference[];
+}
+
+interface PackageDescriptor {
+	/* The list of properties of a package that can be used to identify it */
+	[attr: string]: any;
+}
+
+```
+* error: code and message set in case an exception happens during the definition request.

--- a/extension-workspace-references.md
+++ b/extension-workspace-references.md
@@ -4,6 +4,65 @@ The `workspace/xreferences` extension to the Language Server Protocol (LSP) enab
 
 Use case: clients of a language server can invoke `workspace/xreferences` in order to find references to dependencies. This information can then be stored in a database, which allows the caller to create a "global mapping" of symbols in dependencies to the workspaces they are used in (e.g. to see "how do other people use this symbol?"). A user would perform `textDocument/xdefinition` in order to locate the metadata about the symbol they are interested in and find its references in the database.
 
+### New Identifiers
+
+#### Packages
+
+The extension adds the concept of "packages" to LSP.
+A package is specifically something that would usually be installed through a package manager like npm, Composer or Maven.
+A workspace can contain multiple packages in the form of own packages and dependencies.
+A package is identified by a language-specific interface, that is defined by the language server:
+
+```ts
+/**
+ * The minimal set of properties that identify the package globally, as uniquely as possible.
+ * Depending on the language, can contain a name, a publisher, a package manager, a URL, ...
+ */
+interface PackageIdentifier {
+    [prop: string]: any;
+}
+```
+
+Examples:
+
+```ts
+// TypeScript/JavaScript
+{ name: "express" }
+{ url: "github.com/some/repo" }
+// PHP
+{ name: "symfony/symfony" }
+// Java
+// ?
+// Go
+// ?
+```
+
+#### Symbols
+
+```ts
+/**
+ * The minimal set of properties needed to identify the symbol globally as uniquely as possible
+ */
+interface SymbolIdentifier {
+    /**
+     * If the symbol is part of a package (in a dependency or root package), this property must contain the PackageIdentifier
+     */
+    package?: PackageIdentifier;
+
+    [prop: string]: any;
+}
+```
+
+Examples:
+
+```ts
+// TypeScript
+// PHP
+{ fqsen: "SomeNamespace\\SomeClass::someMethod()" }
+// Java
+// Go
+```
+
 ### Initialization
 
 `ServerCapabilities` may contain a new field to indicate server-side support for this extension:
@@ -43,9 +102,9 @@ _Request_
  */
 interface WorkspaceReferencesParams {
     /**
-     * Metadata about the symbol that is being searched for.
+     * Known properties about the identity of the symbol (for example, the package identifier)
      */
-    query: Partial<SymbolDescriptor>;
+    query: Partial<SymbolIdentifier>;
 
     /**
      * Hints provides optional hints about where the language server should
@@ -72,34 +131,12 @@ interface ReferenceInformation {
     reference: Location;
 
     /**
-     * Metadata about the symbol that can be used to identify or locate its
-     * definition.
+     * Properties of the symbol to identify it
      */
-    symbol: SymbolDescriptor;
+    symbol: SymbolIdentifier;
 }
 ```
 * error: code and message set in case an exception happens during the workspace references request.
-
-Where `SymbolDescriptor` is defined as follows:
-
-```typescript
-/**
- * Represents information about a programming construct that can be used to
- * identify and locate the construct's symbol. The identification does not have
- * to be unique, but it should be as unique as possible. It is up to the
- * language server to define the schema of this object.
- *
- * In contrast to `SymbolInformation`, `SymbolDescriptor` includes more concrete,
- * language-specific, metadata about the symbol.
- */
-interface SymbolDescriptor {
-    /**
-     * A list of properties of a symbol that can be used to identify or locate
-     * it.
-     */
-    [attr: string]: any
-}
-```
 
 ### Goto Definition Extension Request
 
@@ -120,10 +157,9 @@ interface SymbolLocationInformation {
     location?: Location;
 
     /**
-     * Metadata about the symbol that can be used to identify or locate its
-     * definition.
+     * Properties of the symbol to identify it
      */
-    symbol: SymbolDescriptor;
+    symbol: SymbolIdentifier;
 }
 ```
 * error: code and message set in case an exception happens during the definition request.
@@ -157,6 +193,6 @@ interface WorkspaceSymbolParams {
     /**
      * Known properties about the symbol.
      */
-    symbol?: Partial<SymbolDescriptor>;
+    symbol?: Partial<SymbolIdentifier>;
 }
 ```


### PR DESCRIPTION
As discussed with @beyang and @slimsag 

This renames the `Descriptor` interfaces to `Identifier` to make it clear that they are different from eg `SymbolInformation`.
The `SymbolIdentifer` interface is now clearly speced to contain a `PackageIdentifier` field.
Only properties that are speced should be extracted, so if there is anything missing in the identifier interfaces that we need to extract, now is the time to speak up.

It also describes more clearly the new concept of "packages". I actually thought about renaming the extension to the packages extension (and merge the capability flags) since all methods revolve around packages and dependencies.

I would like to get more examples from languages before merging and merge the xpackages branch into this one.

Open questions about `PackageDescriptor`:
- Do we need to extract a name?
- Do we need to identify a package @ a specific version?