### PR TITLE
RFC: Streaming support

### DIFF
--- a/protocol.md
+++ b/protocol.md
@@ -266,7 +266,7 @@ interface PartialResultParams {
 The receiver can listen for partial result notifications with the request ID and use the provided JSON patches to build up a result.
 The result is _not_ required to conform to the result interface while still being built.
 For example, a language server might first return an array of several `Location`s with just the URI set and then fill out the ranges with patches.
-The result is indicated as complete by the final response to the request, which can contain just `null` as value for `result` if the client expressed support for streaming through `ClientCapabilities`.
+The result is indicated as complete by the final response to the request, which, assuming the client expressed support for streaming through `ClientCapabilities`, does not contain any data itself (`result` must be `null`).
 The same applies for requests sent from the server to the client (see `ServerCapabilities`).
 A result built by applying all patches sent through `$/partialResult` should eventually yield in the exact same result as a non-streamed response result.
 

--- a/protocol.md
+++ b/protocol.md
@@ -902,9 +902,8 @@ export interface TextDocumentClientCapabilities {
 ```typescript
 interface ClientCapabilities {
 	/**
-	 * The client supports $/partialResult notifications.
-	 * If true, the server is allowed to let the result in the final response be null
-	 * and only send the result through $/partialResult
+	 * The client supports receiving the result solely through $/partialResult notifications for requests from the client to the server.
+	 * If true, the server is allowed to let the result in the final response be null.
 	 */
 	streaming?: boolean;
 
@@ -1095,9 +1094,8 @@ export interface TextDocumentSyncOptions {
 
 interface ServerCapabilities {
 	/**
-	 * The server supports $/partialResult notifications.
-	 * If true, the client is allowed to let the result in the final response be null
-	 * and only send the result through $/partialResult
+	 * The server supports receiving results solely through $/partialResult notifications for requests from the server to the client.
+	 * If true, the client is allowed to let the result in the final response be null.
 	 */
 	streaming?: boolean;
 	/**

--- a/protocol.md
+++ b/protocol.md
@@ -903,7 +903,7 @@ export interface TextDocumentClientCapabilities {
 interface ClientCapabilities {
 	/**
 	 * The client supports receiving the result solely through $/partialResult notifications for requests from the client to the server.
-	 * If true, the server is allowed to let the result in the final response be null.
+	 * If true, the server should send all data through $/partialResult and send null as the result in the final response.
 	 */
 	streaming?: boolean;
 
@@ -1095,7 +1095,7 @@ export interface TextDocumentSyncOptions {
 interface ServerCapabilities {
 	/**
 	 * The server supports receiving results solely through $/partialResult notifications for requests from the server to the client.
-	 * If true, the client is allowed to let the result in the final response be null.
+	 * If true, the client should send all data through $/partialResult and send null as the result in the final response.
 	 */
 	streaming?: boolean;
 	/**


### PR DESCRIPTION
_This is a proposal for a PR to Microsoft's repo_

-------------------------------------

This is a proposal for adding "streaming" support to LSP, more specifically: The use case of wanting to return parts of a result before the full result is finished. This is especially desirable for methods that can return lots of results like `workspace/symbol`, `textDocument/completion` and are therefor often expensive, even when the UI can only shows a subset of the full response anyway.

There are a couple of approaches to this:
- Using a parser that can parse JSON as a stream
  This is not really viable because a) the order of properties in JSON objects is arbitrary and b) the protocol requires to send a `Content-Length` header, so the sender needs to know the full content in advance
- Polling the server for a progress / updates
  Polling results in unnecessary overhead. With the request the client expressed clear interest in the result, so the server should provide what it has as soon as possible.

Introducing a new method (`$/partialResult`) that the _server_ calls on the _client_ is therefor the best approach. This new method should be passed a request ID the server is returning partial results for and the partial data itself.

The data structure used to represent the partial result should work for all methods. In the simplest case, that means adding items to a result array. That should also work if the array is nested inside an object - for example, `textDocument/completion` returns an object with `isIncomplete` and `items`. The language server should be able to fill out the `isIncomplete` as well as add new items to the `items` array with partial results. The language server should also have the ability to provide partial objects, then fill out missing properties later. For example, it should be able to provide `Location`s with just URIs initially or `SymbolInformation`s with just the name, then fill out the `range` later because it might be expensive to compute and not desirable to keep in memory. The client could then already make use of the partial information.

Just trying to "merge" multiple objects/arrays together will not suffice for this as there would be no way to address specific array indices or to append to an array.

In addition, using a well-defined standard would have the benefit of having libraries available in many languages that ease implementation.

This is solved by [JSON Patch](http://jsonpatch.com/). A JSON Patch is nothing but an array of _operations_ which modify a value at a certain path. In particular, it is possible to add more items to arrays as well as add properties to objects no matter how nested the value is inside the result.

The client would just continuously apply the operations to a result and then for example rerender the UI. The UI might have to be modified so it handles undefined values, for example by showing _Loading..._ where it would normally show certain properties or filtering items that it cannot display because of incompleteness. It might also cancel the request after it has received the information it was looking for.

The final response indicates the result is complete. If the receiver opted into streaming through the `Server`/`ClientCapability` then the response result can just be `null`. Applying all patches sent through `$/partialResult` should yield to the exact same result as a not streamed response.

JSON Patch has libraries for almost every language including JS, Python, PHP, Ruby, Perl, C, Java, C#, Go, Haskell and Erlang. This should make implementation easy for clients and servers.

Simple example:

```ts
// --> Client sends a references request
{ id: 1, method: "textDocument/references", params: {} }
// Result at the client: undefined

// <-- Server sends a partial result that initializes the result to an empty array
{
	method: "$/partialResult",
	params: {
		id: 1,
		patch: [{ op: "replace", path: "", value: [] }]
	}
}
// Result at the client: []

// <-- Server sends zero to n partial results that append a Location to the array
{
	method: "$/partialResult",
	params: {
		id: 1,
		patch: [{ op: "add", path: "/-", value: { uri: "file:///a/file", range: { start: { line: 1, character: 2 }, end: { line: 1, character: 3 }}}]
	}
}
// Result at the client:  [{ uri: "file:///a/file", range: { start: { line: 1, character: 2 }, end: { line: 1, character: 3 }}}]

// <-- Server sends the final response
{
	id: 1,
	result: [{ uri: "file:///a/file", range: { start: { line: 1, character: 2 }, end: { line: 1, character: 3 }}}]
}
```

We experimented with this proposal at Sourcegraph in two language servers and are working on a VS Code client implementation.