### PR TITLE
RFE: Ability to serve binary content

### DIFF
--- a/extension-files.md
+++ b/extension-files.md
@@ -48,6 +48,10 @@ interface ContentParams {
    * The text document to receive the content for.
    */
   textDocument: TextDocumentIdentifier;
+  /**
+   * Indicates that caller expects content to be BASE64-encoded
+   */
+  binary?: boolean;
 }
 ```
 


### PR DESCRIPTION
For java language server there is a need to fetch binary files from VFS. Examples:
- Maven-based project may refer to "system" dependencies where path points to a jar/zip file inside workspace
- Ant-based project almost always refers to local jar/zip files (unless combined with Ivy or downloads them from internet)

The problem with the current `textDocument/xcontent` is that neither client nor server can declare that file being transmitted is a binary one. Thus, we may lose some bytes when binary content is being transformed from bytes to string and in opposite direction, making received file corrupted

In order to resolve this, I would like to propose to add optional `binary` parameter to `textDocument/xcontent`. When client passes positive `binary` parameter, server is expected to send back BASE64-encoded data and client will be able to restore it back to bytes without losing information

WDYT?