### PR TITLE
Make `title` in `window/progress` optional

### DIFF
--- a/protocol.md
+++ b/protocol.md
@@ -1340,10 +1340,10 @@ interface ProgressParams {
   id: string;
 
   /**
-   * The title of the progress.
-   * This should be the same for all ProgressParams with the same id.
+   * Optional title of the progress.
+   * If unset, the previous title (if any) is still valid.
    */
-  title: string;
+  title?: string;
 
   /**
    * Optional progress message to display.


### PR DESCRIPTION
Proposing this as of https://github.com/Microsoft/language-server-protocol/pull/245#issuecomment-334301051.
Existing discussion regarding the title: https://github.com/sourcegraph/language-server-protocol/pull/21#discussion_r115819673.